### PR TITLE
Add package_data to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,4 +4,6 @@ setuptools.setup(
     name='archer',
     version='1.0',
     packages=setuptools.find_packages(),
+    include_package_data=True,
+    package_data={"archer": ["etc/*"]},
 )


### PR DESCRIPTION
Ensure "etc" files are installed when pip installing in site-packages, vs editable mode.

Without package_data included in setup.py, the non-python files are not copied to the system install location, so the files in "/etc" are not available during processing.

pip installing after adding "package_data":
lib/python3.9/site-packages/archer/etc/new_world.nc
